### PR TITLE
do not include .gz files.

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -70,7 +70,7 @@
 							<arch>x86_64</arch>
 						</environment>
 					</environments>
-					<includePackedArtifacts>true</includePackedArtifacts>
+					<includePackedArtifacts>false</includePackedArtifacts>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Would be great if it *only* included .gz files to save
more space but I did not find a way to easily do it. 

Maybe this is the simplest/best thing for now ?