### PR TITLE
Add hover for package fragments

### DIFF
--- a/org.jboss.tools.vscode.java/src/copied/org/eclipse/jdt/internal/corext/javadoc/JavaDocCommentReader.java
+++ b/org.jboss.tools.vscode.java/src/copied/org/eclipse/jdt/internal/corext/javadoc/JavaDocCommentReader.java
@@ -23,6 +23,8 @@ public class JavaDocCommentReader extends SingleCharReader {
 
 	private IBuffer fBuffer;
 
+	private String fSource;
+
 	private int fCurrPos;
 
 	private int fStartPos;
@@ -39,21 +41,29 @@ public class JavaDocCommentReader extends SingleCharReader {
 		reset();
 	}
 
+	public JavaDocCommentReader(String source, int start, int end) {
+		fSource= source;
+		fStartPos= start + 3;
+		fEndPos= end - 2;
+
+		reset();
+	}
+
 	/**
 	 * @see java.io.Reader#read()
 	 */
 	@Override
 	public int read() {
 		if (fCurrPos < fEndPos) {
-			char ch= fBuffer.getChar(fCurrPos++);
+			char ch= getChar(fCurrPos++);
 			if (fWasNewLine && !IndentManipulation.isLineDelimiterChar(ch)) {
 				while (fCurrPos < fEndPos && Character.isWhitespace(ch)) {
-					ch= fBuffer.getChar(fCurrPos++);
+					ch= getChar(fCurrPos++);
 				}
 				if (ch == '*') {
 					if (fCurrPos < fEndPos) {
 						do {
-							ch= fBuffer.getChar(fCurrPos++);
+							ch= getChar(fCurrPos++);
 						} while (ch == '*');
 					} else {
 						return -1;
@@ -72,6 +82,7 @@ public class JavaDocCommentReader extends SingleCharReader {
 	 */
 	@Override
 	public void close() {
+		fSource = null;
 		fBuffer= null;
 	}
 
@@ -83,23 +94,27 @@ public class JavaDocCommentReader extends SingleCharReader {
 		fCurrPos= fStartPos;
 		fWasNewLine= true;
 		// skip first line delimiter:
-		if (fCurrPos < fEndPos && '\r' == fBuffer.getChar(fCurrPos)) {
+		if (fCurrPos < fEndPos && '\r' == getChar(fCurrPos)) {
 			fCurrPos++;
 		}
-		if (fCurrPos < fEndPos && '\n' == fBuffer.getChar(fCurrPos)) {
+		if (fCurrPos < fEndPos && '\n' == getChar(fCurrPos)) {
 			fCurrPos++;
 		}
 	}
 
+	private char getChar(int pos) {
+		if (fBuffer != null) {
+			return fBuffer.getChar(fCurrPos);
+		}
+		return fSource.charAt(pos);
+	}
 
 	/**
 	 * Returns the offset of the last read character in the passed buffer.
-	 * 
+	 *
 	 * @return the offset
 	 */
 	public int getOffset() {
 		return fCurrPos;
 	}
-
-
 }

--- a/org.jboss.tools.vscode.java/src/copied/org/eclipse/jdt/ui/JavadocContentAccess.java
+++ b/org.jboss.tools.vscode.java/src/copied/org/eclipse/jdt/ui/JavadocContentAccess.java
@@ -13,16 +13,27 @@ package copied.org.eclipse.jdt.ui;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.Map;
 
 import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaModelStatusConstants;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.ITypeHierarchy;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Javadoc;
+import org.eclipse.jdt.core.dom.PackageDeclaration;
 import org.jboss.tools.vscode.javadoc.internal.JavaDoc2MarkdownConverter;
 
 import copied.org.eclipse.jdt.internal.corext.javadoc.JavaDocCommentReader;
@@ -41,6 +52,15 @@ import copied.org.eclipse.jdt.internal.corext.util.MethodOverrideTester;
  * @noextend This class is not intended to be subclassed by clients.
  */
 public class JavadocContentAccess {
+	/**
+	 * The name of the package-info.java file.
+	 */
+	public static final String PACKAGE_INFO_JAVA= "package-info.java"; //$NON-NLS-1$
+
+	/**
+	 * The name of the package-info.class file.
+	 */
+	public static final String PACKAGE_INFO_CLASS= "package-info.class"; //$NON-NLS-1$
 
 	private JavadocContentAccess() {
 		// do not instantiate
@@ -90,6 +110,66 @@ public class JavadocContentAccess {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Gets a reader for an package fragment's Javadoc comment content from the source attachment.
+	 * The content does contain only the text from the comment without the Javadoc leading star characters.
+	 * Returns <code>null</code> if the package fragment does not contain a Javadoc comment or if no source is available.
+	 * @param fragment The package fragment to get the Javadoc of.
+	 * @return Returns a reader for the Javadoc comment content or <code>null</code> if the member
+	 * does not contain a Javadoc comment or if no source is available
+	 * @throws JavaModelException is thrown when the package fragment's javadoc can not be accessed
+	 * @since 3.4
+	 */
+	private static Reader internalGetContentReader(IPackageFragment fragment) throws JavaModelException {
+		IPackageFragmentRoot root= (IPackageFragmentRoot) fragment.getAncestor(IJavaElement.PACKAGE_FRAGMENT_ROOT);
+
+		//1==> Handle the case when the documentation is present in package-info.java or package-info.class file
+		boolean isBinary= root.getKind() == IPackageFragmentRoot.K_BINARY;
+		ITypeRoot packageInfo;
+		if (isBinary) {
+			packageInfo= fragment.getClassFile(PACKAGE_INFO_CLASS);
+		} else {
+			packageInfo= fragment.getCompilationUnit(PACKAGE_INFO_JAVA);
+		}
+		if (packageInfo != null && packageInfo.exists()) {
+			String source = packageInfo.getSource();
+			//the source can be null for some of the class files
+			if (source != null) {
+				Javadoc javadocNode = getPackageJavadocNode(fragment, source);
+				if (javadocNode != null) {
+					int start = javadocNode.getStartPosition();
+					int length = javadocNode.getLength();
+					return new JavaDocCommentReader(source, start, start + length - 1);
+				}
+			}
+		}
+		return null;
+	}
+
+	private static Javadoc getPackageJavadocNode(IJavaElement element, String cuSource) {
+		CompilationUnit cu= createAST(element, cuSource);
+		if (cu != null) {
+			PackageDeclaration packDecl= cu.getPackage();
+			if (packDecl != null) {
+				return packDecl.getJavadoc();
+			}
+		}
+		return null;
+	}
+
+	private static CompilationUnit createAST(IJavaElement element, String cuSource) {
+		ASTParser parser= ASTParser.newParser(AST.JLS8);
+
+		IJavaProject javaProject= element.getJavaProject();
+		parser.setProject(javaProject);
+		Map<String, String> options= javaProject.getOptions(true);
+		options.put(JavaCore.COMPILER_DOC_COMMENT_SUPPORT, JavaCore.ENABLED); // workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=212207
+		parser.setCompilerOptions(options);
+
+		parser.setSource(cuSource.toCharArray());
+		return (CompilationUnit) parser.createAST(null);
 	}
 
 	/**
@@ -146,6 +226,49 @@ public class JavadocContentAccess {
 		if (allowInherited && (member.getElementType() == IJavaElement.METHOD))
 			return findDocInHierarchy((IMethod) member, true, useAttachedJavadoc);
 
+		return null;
+	}
+
+	/**
+	 * Gets a reader for a package fragment's Javadoc comment content from the source attachment.
+	 * and renders the tags in HTML.
+	 * Returns <code>null</code> if the package fragment does not contain a Javadoc comment or if no source is available.
+	 *
+	 * @param fragment				the package fragment to get the Javadoc of.
+	 * @param useAttachedJavadoc	if <code>true</code> Javadoc will be extracted from attached Javadoc
+	 * 									if there's no source
+	 * @return a reader for the Javadoc comment content in HTML or <code>null</code> if the package fragment
+	 * 			does not contain a Javadoc comment or if no source is available
+	 * @throws JavaModelException is thrown when the package fragment's Javadoc can not be accessed
+	 * @since 3.2
+	 */
+	public static Reader getHTMLContentReader(IPackageFragment fragment, boolean useAttachedJavadoc) throws JavaModelException {
+		Reader contentReader= internalGetContentReader(fragment);
+		if (contentReader != null) {
+			try {
+				return new JavaDoc2MarkdownConverter(contentReader).getAsReader();
+			} catch (IOException e) {
+				throw new JavaModelException(e, IJavaModelStatusConstants.UNKNOWN_JAVADOC_FORMAT);
+			}
+		}
+		if (useAttachedJavadoc) {
+			// only if no source available
+			// check parent
+			IPackageFragmentRoot root= (IPackageFragmentRoot) fragment.getAncestor(IJavaElement.PACKAGE_FRAGMENT_ROOT);
+
+			//1==> Handle the case when the documentation is present in package-info.java or package-info.class file
+			boolean isBinary= root.getKind() == IPackageFragmentRoot.K_BINARY;
+			if (isBinary) {
+				String s= fragment.getAttachedJavadoc(null);
+				if (s != null) {
+					try {
+						return new JavaDoc2MarkdownConverter(new StringReader(s)).getAsReader();
+					} catch (IOException e) {
+						throw new JavaModelException(e, IJavaModelStatusConstants.UNKNOWN_JAVADOC_FORMAT);
+					}
+				}
+			}
+		}
 		return null;
 	}
 

--- a/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/HoverInfoProvider.java
+++ b/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/HoverInfoProvider.java
@@ -13,50 +13,60 @@ package org.jboss.tools.vscode.java.internal;
 import java.io.IOException;
 import java.io.Reader;
 
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.ILocalVariable;
 import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.ISourceRange;
-import org.eclipse.jdt.core.ISourceReference;
 import org.eclipse.jdt.core.ITypeParameter;
 import org.eclipse.jdt.core.ITypeRoot;
-import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.internal.core.util.Util;
-import org.eclipse.jface.text.BadLocationException;
-import org.eclipse.jface.text.DefaultLineTracker;
-import org.eclipse.jface.text.Document;
-import org.eclipse.jface.text.IDocument;
-import org.eclipse.jface.text.ILineTracker;
-import org.eclipse.jface.text.IRegion;
 import org.jboss.tools.vscode.java.internal.handlers.JsonRpcHelpers;
 
 import copied.org.eclipse.jdt.ui.JavadocContentAccess;
 
 public class HoverInfoProvider {
-	
+
 	private final ITypeRoot unit;
 	public HoverInfoProvider(ITypeRoot aUnit) {
 		this.unit = aUnit;
 	}
-	
+
 	public String computeHover(int line, int column) {
 		try {
 			IJavaElement[] elements = unit.codeSelect(JsonRpcHelpers.toOffset(unit.getBuffer(),line,column),0);
-			if(elements == null || elements.length != 1)
+			if(elements == null) {
 				return null;
-			IJavaElement curr= elements[0];
-//			return computeSourceHover(curr);
+			}
+			IJavaElement curr = null;
+			if (elements.length != 1) {
+				// they could be package fragments.
+				// We need to select the one that matches the package fragment of the current unit
+				IJavaElement found = null;
+				IPackageFragment packageFragment = (IPackageFragment) unit.getParent();
+				loop: for (IJavaElement element : elements) {
+					if (packageFragment.equals(element)) {
+						found = element;
+						break loop;
+					}
+				}
+				if (found == null) {
+					// this would be a binary package fragment
+					return computeJavadocHover(elements[0]);
+				}
+				curr = found;
+			} else {
+				curr = elements[0];
+			}
 			return computeJavadocHover(curr);
-			
-		} catch (JavaModelException e) {
-			// TODO Auto-generated catch block
+		} catch (CoreException e) {
 			e.printStackTrace();
 		}
 		return null;
 	}
 
-	private String computeJavadocHover(IJavaElement element) throws JavaModelException{
+	private String computeJavadocHover(IJavaElement element) throws CoreException {
 		IMember member;
 		if (element instanceof ILocalVariable) {
 			member= ((ILocalVariable) element).getDeclaringMember();
@@ -64,10 +74,14 @@ public class HoverInfoProvider {
 			member= ((ITypeParameter) element).getDeclaringMember();
 		} else if (element instanceof IMember) {
 			member= (IMember) element;
+		} else if (element instanceof IPackageFragment) {
+			Reader r = JavadocContentAccess.getHTMLContentReader((IPackageFragment) element, true);
+			if(r == null ) return null;
+			return getString(r);
 		} else {
 			return null;
 		}
-		
+
 		IBuffer buf= member.getOpenable().getBuffer();
 		if (buf == null) {
 			return null; // no source attachment found
@@ -79,75 +93,7 @@ public class HoverInfoProvider {
 		if(r == null ) return null;
 		return getString(r);
 	}
-	
-	
-	/**
-	 * Returns source as hover
-	 * @param curr
-	 * @return
-	 */
-	private String computeSourceHover(IJavaElement curr) {
-		if ((curr instanceof IMember || curr instanceof ILocalVariable || curr instanceof ITypeParameter) && curr instanceof ISourceReference) {
-			try {
-				String source= ((ISourceReference) curr).getSource();
 
-				String[] sourceLines= getTrimmedSource(source, curr);
-				if (sourceLines == null)
-					return null;
-
-				String delim= Util.getLineSeparator(source,unit.getJavaProject()); 
-				source= concatenate(sourceLines, delim);
-
-				return source;
-			} catch (JavaModelException ex) {
-				//do nothing
-			}
-		}
-		return null;
-	}
-	
-	
-	/**
-	 * Returns the trimmed source lines.
-	 *
-	 * @param source the source string, could be <code>null</code>
-	 * @param javaElement the java element
-	 * @return the trimmed source lines or <code>null</code>
-	 */
-	private String[] getTrimmedSource(String source, IJavaElement javaElement) {
-		if (source == null)
-			return null;
-		source= removeLeadingComments(source);
-		String[] sourceLines= convertIntoLines(source);
-//		Strings.trimIndentation(sourceLines, javaElement.getJavaProject());
-		return sourceLines;
-	}
-	
-	private String removeLeadingComments(String source) {
-		final JavaCodeReader reader= new JavaCodeReader();
-		IDocument document= new Document(source);
-		int i;
-		try {
-			reader.configureForwardReader(document, 0, document.getLength(), true, false);
-			int c= reader.read();
-			while (c != -1 && (c == '\r' || c == '\n')) {
-				c= reader.read();
-			}
-			i= reader.getOffset();
-			reader.close();
-		} catch (IOException ex) {
-			i= 0;
-		} finally {
-			try {
-				reader.close();
-			} catch (IOException ex) {
-			}
-		}
-
-		if (i < 0)
-			return source;
-		return source.substring(i);
-	}
 	/**
 	 * Gets the reader content as a String
 	 *
@@ -165,47 +111,5 @@ public class HoverInfoProvider {
 			return null;
 		}
 		return buf.toString();
-	}
-	
-	/**
-	 * Converts the given string into an array of lines. The lines
-	 * don't contain any line delimiter characters.
-	 *
-	 * @param input the string
-	 * @return the string converted into an array of strings. Returns <code>
-	 * 	null</code> if the input string can't be converted in an array of lines.
-	 */
-	public static String[] convertIntoLines(String input) {
-		try {
-			ILineTracker tracker= new DefaultLineTracker();
-			tracker.set(input);
-			int size= tracker.getNumberOfLines();
-			String result[]= new String[size];
-			for (int i= 0; i < size; i++) {
-				IRegion region= tracker.getLineInformation(i);
-				int offset= region.getOffset();
-				result[i]= input.substring(offset, offset + region.getLength());
-			}
-			return result;
-		} catch (BadLocationException e) {
-			return null;
-		}
-	}
-	
-	/**
-	 * Concatenate the given strings into one strings using the passed line delimiter as a
-	 * delimiter. No delimiter is added to the last line.
-	 * @param lines the lines
-	 * @param delimiter line delimiter
-	 * @return the concatenated lines
-	 */
-	public static String concatenate(String[] lines, String delimiter) {
-		StringBuilder buffer= new StringBuilder();
-		for (int i= 0; i < lines.length; i++) {
-			if (i > 0)
-				buffer.append(delimiter);
-			buffer.append(lines[i]);
-		}
-		return buffer.toString();
 	}
 }

--- a/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/HoverInfoProvider.java
+++ b/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/HoverInfoProvider.java
@@ -12,6 +12,7 @@ package org.jboss.tools.vscode.java.internal;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.util.stream.Stream;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IBuffer;
@@ -23,8 +24,6 @@ import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.ITypeParameter;
 import org.eclipse.jdt.core.ITypeRoot;
 import org.jboss.tools.vscode.java.internal.handlers.JsonRpcHelpers;
-
-import copied.org.eclipse.jdt.ui.JavadocContentAccess;
 
 public class HoverInfoProvider {
 
@@ -43,6 +42,7 @@ public class HoverInfoProvider {
 			if (elements.length != 1) {
 				// they could be package fragments.
 				// We need to select the one that matches the package fragment of the current unit
+<<<<<<< HEAD
 				IJavaElement found = null;
 				IPackageFragment packageFragment = (IPackageFragment) unit.getParent();
 				loop: for (IJavaElement element : elements) {
@@ -51,6 +51,15 @@ public class HoverInfoProvider {
 						break loop;
 					}
 				}
+=======
+				IPackageFragment packageFragment = (IPackageFragment) unit.getParent();
+				IJavaElement found =
+						Stream
+						.of(elements)
+						.filter(e -> e.equals(packageFragment))
+						.findFirst()
+						.orElse(null);
+>>>>>>> e944b4f2041bd206d80d53861dc1579cbec6d266
 				if (found == null) {
 					// this would be a binary package fragment
 					return computeJavadocHover(elements[0]);

--- a/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/JavadocContentAccess.java
+++ b/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/JavadocContentAccess.java
@@ -1,0 +1,305 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.jboss.tools.vscode.java.internal;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Map;
+
+import org.eclipse.jdt.core.IBuffer;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaModelStatusConstants;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.ISourceRange;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeHierarchy;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.Javadoc;
+import org.eclipse.jdt.core.dom.PackageDeclaration;
+import org.jboss.tools.vscode.java.internal.hover.JavaDocCommentReader;
+import org.jboss.tools.vscode.javadoc.internal.JavaDoc2MarkdownConverter;
+
+import copied.org.eclipse.jdt.internal.corext.util.MethodOverrideTester;
+
+/**
+ * Helper needed to get the content of a Javadoc comment.
+ *
+ * <p>
+ * This class is not intended to be subclassed or instantiated by clients.
+ * </p>
+ *
+ * @since 3.1
+ *
+ * @noinstantiate This class is not intended to be instantiated by clients.
+ * @noextend This class is not intended to be subclassed by clients.
+ */
+public class JavadocContentAccess {
+	/**
+	 * The name of the package-info.java file.
+	 */
+	public static final String PACKAGE_INFO_JAVA= "package-info.java"; //$NON-NLS-1$
+
+	/**
+	 * The name of the package-info.class file.
+	 */
+	public static final String PACKAGE_INFO_CLASS= "package-info.class"; //$NON-NLS-1$
+
+	private JavadocContentAccess() {
+		// do not instantiate
+	}
+
+	/**
+	 * Gets a reader for an IMember's Javadoc comment content from the source attachment.
+	 * The content does contain only the text from the comment without the Javadoc leading star characters.
+	 * Returns <code>null</code> if the member does not contain a Javadoc comment or if no source is available.
+	 * @param member The member to get the Javadoc of.
+	 * @param allowInherited For methods with no (Javadoc) comment, the comment of the overridden class
+	 * is returned if <code>allowInherited</code> is <code>true</code>.
+	 * @return Returns a reader for the Javadoc comment content or <code>null</code> if the member
+	 * does not contain a Javadoc comment or if no source is available
+	 * @throws JavaModelException is thrown when the elements javadoc can not be accessed
+	 */
+	public static Reader getContentReader(IMember member, boolean allowInherited) throws JavaModelException {
+		Reader contentReader= internalGetContentReader(member);
+		if (contentReader != null || !(allowInherited && (member.getElementType() == IJavaElement.METHOD)))
+			return contentReader;
+		return findDocInHierarchy((IMethod) member, false, false);
+	}
+
+	/**
+	 * Gets a reader for an IMember's Javadoc comment content from the source attachment.
+	 * The content does contain only the text from the comment without the Javadoc leading star characters.
+	 * Returns <code>null</code> if the member does not contain a Javadoc comment or if no source is available.
+	 * @param member The member to get the Javadoc of.
+	 * @return Returns a reader for the Javadoc comment content or <code>null</code> if the member
+	 * does not contain a Javadoc comment or if no source is available
+	 * @throws JavaModelException is thrown when the elements javadoc can not be accessed
+	 * @since 3.4
+	 */
+	private static Reader internalGetContentReader(IMember member) throws JavaModelException {
+		IBuffer buf= member.getOpenable().getBuffer();
+		if (buf == null) {
+			return null; // no source attachment found
+		}
+
+		ISourceRange javadocRange= member.getJavadocRange();
+		if (javadocRange != null) {
+			JavaDocCommentReader reader= new JavaDocCommentReader(buf, javadocRange.getOffset(), javadocRange.getOffset() + javadocRange.getLength() - 1);
+			if (!containsOnlyInheritDoc(reader, javadocRange.getLength())) {
+				reader.reset();
+				return reader;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Gets a reader for an package fragment's Javadoc comment content from the source attachment.
+	 * The content does contain only the text from the comment without the Javadoc leading star characters.
+	 * Returns <code>null</code> if the package fragment does not contain a Javadoc comment or if no source is available.
+	 * @param fragment The package fragment to get the Javadoc of.
+	 * @return Returns a reader for the Javadoc comment content or <code>null</code> if the member
+	 * does not contain a Javadoc comment or if no source is available
+	 * @throws JavaModelException is thrown when the package fragment's javadoc can not be accessed
+	 * @since 3.4
+	 */
+	private static Reader internalGetContentReader(IPackageFragment fragment) throws JavaModelException {
+		IPackageFragmentRoot root= (IPackageFragmentRoot) fragment.getAncestor(IJavaElement.PACKAGE_FRAGMENT_ROOT);
+
+		//1==> Handle the case when the documentation is present in package-info.java or package-info.class file
+		boolean isBinary= root.getKind() == IPackageFragmentRoot.K_BINARY;
+		ITypeRoot packageInfo;
+		if (isBinary) {
+			packageInfo= fragment.getClassFile(PACKAGE_INFO_CLASS);
+		} else {
+			packageInfo= fragment.getCompilationUnit(PACKAGE_INFO_JAVA);
+		}
+		if (packageInfo != null && packageInfo.exists()) {
+			String source = packageInfo.getSource();
+			//the source can be null for some of the class files
+			if (source != null) {
+				Javadoc javadocNode = getPackageJavadocNode(fragment, source);
+				if (javadocNode != null) {
+					int start = javadocNode.getStartPosition();
+					int length = javadocNode.getLength();
+					return new JavaDocCommentReader(source, start, start + length - 1);
+				}
+			}
+		}
+		return null;
+	}
+
+	private static Javadoc getPackageJavadocNode(IJavaElement element, String cuSource) {
+		CompilationUnit cu= createAST(element, cuSource);
+		if (cu != null) {
+			PackageDeclaration packDecl= cu.getPackage();
+			if (packDecl != null) {
+				return packDecl.getJavadoc();
+			}
+		}
+		return null;
+	}
+
+	private static CompilationUnit createAST(IJavaElement element, String cuSource) {
+		ASTParser parser= ASTParser.newParser(AST.JLS8);
+
+		IJavaProject javaProject= element.getJavaProject();
+		parser.setProject(javaProject);
+		Map<String, String> options= javaProject.getOptions(true);
+		options.put(JavaCore.COMPILER_DOC_COMMENT_SUPPORT, JavaCore.ENABLED); // workaround for https://bugs.eclipse.org/bugs/show_bug.cgi?id=212207
+		parser.setCompilerOptions(options);
+
+		parser.setSource(cuSource.toCharArray());
+		return (CompilationUnit) parser.createAST(null);
+	}
+
+	/**
+	 * Checks whether the given reader only returns
+	 * the inheritDoc tag.
+	 *
+	 * @param reader the reader
+	 * @param length the length of the underlying content
+	 * @return <code>true</code> if the reader only returns the inheritDoc tag
+	 * @since 3.2
+	 */
+	private static boolean containsOnlyInheritDoc(Reader reader, int length) {
+		char[] content= new char[length];
+		try {
+			reader.read(content, 0, length);
+		} catch (IOException e) {
+			return false;
+		}
+		return new String(content).trim().equals("{@inheritDoc}"); //$NON-NLS-1$
+
+	}
+
+	/**
+	 * Gets a reader for an IMember's Javadoc comment content from the source attachment.
+	 * and renders the tags in HTML.
+	 * Returns <code>null</code> if the member does not contain a Javadoc comment or if no source is available.
+	 *
+	 * @param member				the member to get the Javadoc of.
+	 * @param allowInherited		for methods with no (Javadoc) comment, the comment of the overridden
+	 * 									class is returned if <code>allowInherited</code> is <code>true</code>
+	 * @param useAttachedJavadoc	if <code>true</code> Javadoc will be extracted from attached Javadoc
+	 * 									if there's no source
+	 * @return a reader for the Javadoc comment content in HTML or <code>null</code> if the member
+	 * 			does not contain a Javadoc comment or if no source is available
+	 * @throws JavaModelException is thrown when the elements Javadoc can not be accessed
+	 * @since 3.2
+	 */
+	public static Reader getHTMLContentReader(IMember member, boolean allowInherited, boolean useAttachedJavadoc) throws JavaModelException {
+		Reader contentReader= internalGetContentReader(member);
+		if (contentReader != null) {
+			try {
+				return new JavaDoc2MarkdownConverter(contentReader).getAsReader();
+			} catch (IOException e) {
+				throw new JavaModelException(e, IJavaModelStatusConstants.UNKNOWN_JAVADOC_FORMAT);
+			}
+		}
+
+		if (useAttachedJavadoc && member.getOpenable().getBuffer() == null) { // only if no source available
+			String s= member.getAttachedJavadoc(null);
+			if (s != null)
+				return new StringReader(s);
+		}
+
+		if (allowInherited && (member.getElementType() == IJavaElement.METHOD))
+			return findDocInHierarchy((IMethod) member, true, useAttachedJavadoc);
+
+		return null;
+	}
+
+	/**
+	 * Gets a reader for a package fragment's Javadoc comment content from the source attachment.
+	 * and renders the tags in HTML.
+	 * Returns <code>null</code> if the package fragment does not contain a Javadoc comment or if no source is available.
+	 *
+	 * @param fragment				the package fragment to get the Javadoc of.
+	 * @param useAttachedJavadoc	if <code>true</code> Javadoc will be extracted from attached Javadoc
+	 * 									if there's no source
+	 * @return a reader for the Javadoc comment content in HTML or <code>null</code> if the package fragment
+	 * 			does not contain a Javadoc comment or if no source is available
+	 * @throws JavaModelException is thrown when the package fragment's Javadoc can not be accessed
+	 * @since 3.2
+	 */
+	public static Reader getHTMLContentReader(IPackageFragment fragment, boolean useAttachedJavadoc) throws JavaModelException {
+		Reader contentReader= internalGetContentReader(fragment);
+		if (contentReader != null) {
+			try {
+				return new JavaDoc2MarkdownConverter(contentReader).getAsReader();
+			} catch (IOException e) {
+				throw new JavaModelException(e, IJavaModelStatusConstants.UNKNOWN_JAVADOC_FORMAT);
+			}
+		}
+		if (useAttachedJavadoc) {
+			// only if no source available
+			// check parent
+			IPackageFragmentRoot root= (IPackageFragmentRoot) fragment.getAncestor(IJavaElement.PACKAGE_FRAGMENT_ROOT);
+
+			//1==> Handle the case when the documentation is present in package-info.java or package-info.class file
+			boolean isBinary= root.getKind() == IPackageFragmentRoot.K_BINARY;
+			if (isBinary) {
+				String s= fragment.getAttachedJavadoc(null);
+				if (s != null) {
+					try {
+						return new JavaDoc2MarkdownConverter(new StringReader(s)).getAsReader();
+					} catch (IOException e) {
+						throw new JavaModelException(e, IJavaModelStatusConstants.UNKNOWN_JAVADOC_FORMAT);
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	private static Reader findDocInHierarchy(IMethod method, boolean isHTML, boolean useAttachedJavadoc) throws JavaModelException {
+		/*
+		 * Catch ExternalJavaProject in which case
+		 * no hierarchy can be built.
+		 */
+		if (!method.getJavaProject().exists())
+			return null;
+
+		IType type= method.getDeclaringType();
+		ITypeHierarchy hierarchy= type.newSupertypeHierarchy(null);
+
+		MethodOverrideTester tester= new MethodOverrideTester(type, hierarchy);
+
+		IType[] superTypes= hierarchy.getAllSupertypes(type);
+		for (int i= 0; i < superTypes.length; i++) {
+			IType curr= superTypes[i];
+			IMethod overridden= tester.findOverriddenMethodInType(curr, method);
+			if (overridden != null) {
+				Reader reader;
+				if (isHTML)
+					reader= getHTMLContentReader(overridden, false, useAttachedJavadoc);
+				else
+					reader= getContentReader(overridden, false);
+				if (reader != null)
+					return reader;
+			}
+		}
+		return null;
+	}
+
+}

--- a/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/handlers/CompletionResolveHandler.java
+++ b/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/handlers/CompletionResolveHandler.java
@@ -28,9 +28,8 @@ import org.jboss.tools.vscode.internal.ipc.CancelMonitor;
 import org.jboss.tools.vscode.internal.ipc.RequestHandler;
 import org.jboss.tools.vscode.java.internal.JDTUtils;
 import org.jboss.tools.vscode.java.internal.JavaLanguageServerPlugin;
+import org.jboss.tools.vscode.java.internal.JavadocContentAccess;
 import org.jboss.tools.vscode.java.internal.SignatureUtil;
-
-import copied.org.eclipse.jdt.ui.JavadocContentAccess;
 
 public class CompletionResolveHandler implements RequestHandler<CompletionItem, CompletionItem> {
 

--- a/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/hover/JavaDocCommentReader.java
+++ b/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/hover/JavaDocCommentReader.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2012 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.jboss.tools.vscode.java.internal.hover;
+
+import org.eclipse.jdt.core.IBuffer;
+import org.eclipse.jdt.core.formatter.IndentManipulation;
+
+import copied.org.eclipse.jface.internal.text.html.SingleCharReader;
+
+
+/**
+ * Reads a java doc comment from a java doc comment. Skips star-character on begin of line.
+ */
+public class JavaDocCommentReader extends SingleCharReader {
+
+	private IBuffer fBuffer;
+
+	private String fSource;
+
+	private int fCurrPos;
+
+	private int fStartPos;
+
+	private int fEndPos;
+
+	private boolean fWasNewLine;
+
+	public JavaDocCommentReader(IBuffer buf, int start, int end) {
+		fBuffer= buf;
+		fStartPos= start + 3;
+		fEndPos= end - 2;
+
+		reset();
+	}
+
+	public JavaDocCommentReader(String source, int start, int end) {
+		fSource= source;
+		fStartPos= start + 3;
+		fEndPos= end - 2;
+
+		reset();
+	}
+
+	/**
+	 * @see java.io.Reader#read()
+	 */
+	@Override
+	public int read() {
+		if (fCurrPos < fEndPos) {
+			char ch= getChar(fCurrPos++);
+			if (fWasNewLine && !IndentManipulation.isLineDelimiterChar(ch)) {
+				while (fCurrPos < fEndPos && Character.isWhitespace(ch)) {
+					ch= getChar(fCurrPos++);
+				}
+				if (ch == '*') {
+					if (fCurrPos < fEndPos) {
+						do {
+							ch= getChar(fCurrPos++);
+						} while (ch == '*');
+					} else {
+						return -1;
+					}
+				}
+			}
+			fWasNewLine= IndentManipulation.isLineDelimiterChar(ch);
+
+			return ch;
+		}
+		return -1;
+	}
+
+	/**
+	 * @see java.io.Reader#close()
+	 */
+	@Override
+	public void close() {
+		fSource = null;
+		fBuffer= null;
+	}
+
+	/**
+	 * @see java.io.Reader#reset()
+	 */
+	@Override
+	public void reset() {
+		fCurrPos= fStartPos;
+		fWasNewLine= true;
+		// skip first line delimiter:
+		if (fCurrPos < fEndPos && '\r' == getChar(fCurrPos)) {
+			fCurrPos++;
+		}
+		if (fCurrPos < fEndPos && '\n' == getChar(fCurrPos)) {
+			fCurrPos++;
+		}
+	}
+
+	private char getChar(int pos) {
+		if (fBuffer != null) {
+			return fBuffer.getChar(fCurrPos);
+		}
+		return fSource.charAt(pos);
+	}
+
+	/**
+	 * Returns the offset of the last read character in the passed buffer.
+	 *
+	 * @return the offset
+	 */
+	public int getOffset() {
+		return fCurrPos;
+	}
+}

--- a/org.jboss.tools.vscode.tests/src/org/jboss/tools/vscode/java/internal/Util.java
+++ b/org.jboss.tools.vscode.tests/src/org/jboss/tools/vscode/java/internal/Util.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.jboss.tools.vscode.java.internal;
+
+public class Util {
+
+	public static String convertToIndependentLineDelimiter(String source) {
+		if (source.indexOf('\n') == -1 && source.indexOf('\r') == -1) return source;
+		StringBuffer buffer = new StringBuffer();
+		for (int i = 0, length = source.length(); i < length; i++) {
+			char car = source.charAt(i);
+			if (car == '\r') {
+				buffer.append('\n');
+				if (i < length-1 && source.charAt(i+1) == '\n') {
+					i++; // skip \n after \r
+				}
+			} else {
+				buffer.append(car);
+			}
+		}
+		return buffer.toString();
+	}
+
+}

--- a/org.jboss.tools.vscode.tests/src/org/jboss/tools/vscode/javadoc/internal/JavaDoc2MarkdownConverterTest.java
+++ b/org.jboss.tools.vscode.tests/src/org/jboss/tools/vscode/javadoc/internal/JavaDoc2MarkdownConverterTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.io.Reader;
 
+import org.jboss.tools.vscode.java.internal.Util;
 import org.junit.Test;
 
 /**
@@ -171,7 +172,7 @@ public class JavaDoc2MarkdownConverterTest {
 	@Test
 	public void testGetAsString() throws IOException {
 		String result = new JavaDoc2MarkdownConverter(RAW_JAVADOC_0).getAsString();
-		assertEquals(MARKDOWN_0, result);
+		assertEquals(Util.convertToIndependentLineDelimiter(MARKDOWN_0), Util.convertToIndependentLineDelimiter(result));
 	}
 
 	@Test


### PR DESCRIPTION
I propose these changes to add some hover contents for a package fragment. This should work for the actual package declaration of the current unit if there is a package-info.java file in the same package or for import statements when you hover on the package part of the import.
Let me know what you think.