### PR TITLE
Fix for parameter with generic types (HashMap type hover).

### DIFF
--- a/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/javadoc/JavaDoc2HTMLTextReader.java
+++ b/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/javadoc/JavaDoc2HTMLTextReader.java
@@ -126,8 +126,7 @@ public class JavaDoc2HTMLTextReader extends SubstitutionTextReader {
 
 				int i= getParamEndOffset(s);
 				if (i <= s.length()) {
-					//buffer.append(convertToHTMLContent(s.substring(0, i)));
-					buffer.append(s.substring(0, i));
+					buffer.append(convertToHTMLContent(s.substring(0, i)));
 					buffer.append("</b>"); //$NON-NLS-1$
 					buffer.append(s.substring(i));
 				} else {
@@ -153,6 +152,7 @@ public class JavaDoc2HTMLTextReader extends SubstitutionTextReader {
 				++i;
 			while (i < length && s.charAt(i) != '>')
 				++i;
+			++i; // >
 		} else {
 			// simply read an identifier
 			while (i < length && Character.isJavaIdentifierPart(s.charAt(i)))


### PR DESCRIPTION
When hovering over HashMap type, the javadoc shown at the end for the Parameters is wrong. It starts with '>' .....
It should prints <K> in bold followed by the parameter description. Some code has been commented out and this is wrong as it doesn't convert the < into &lt;.
The proposed fix prints the right documentation.