### PR TITLE
Support standalone java files (#60)

### DIFF
--- a/org.jboss.tools.vscode.java/META-INF/MANIFEST.MF
+++ b/org.jboss.tools.vscode.java/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.jboss.tools.vscode.ipc;bundle-version="1.0.0",
  com.ibm.icu,
  org.eclipse.core.filebuffers;bundle-version="3.6.0",
  org.eclipse.m2e.maven.runtime,
- com.google.guava
+ com.google.guava,
+ org.eclipse.jdt.launching
 Export-Package: org.jboss.tools.vscode.java.internal;x-friends:="org.jboss.tools.vscode.tests",
  org.jboss.tools.vscode.java.internal.managers;x-friends:="org.jboss.tools.vscode.tests",
  org.jboss.tools.vscode.java.internal.javadoc;x-friends:="org.jboss.tools.vscode.tests"

--- a/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/JDTUtils.java
+++ b/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/JDTUtils.java
@@ -10,26 +10,46 @@
  *******************************************************************************/
 package org.jboss.tools.vscode.java.internal;
 
+import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Paths;
 
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.IClassFile;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.ISourceReference;
 import org.eclipse.jdt.core.ITypeRoot;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.PackageDeclaration;
 import org.jboss.tools.langs.Location;
 import org.jboss.tools.langs.Position;
 import org.jboss.tools.langs.Range;
 import org.jboss.tools.vscode.java.internal.handlers.JsonRpcHelpers;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 
 /**
  * General utilities for working with JDT APIs
@@ -43,30 +63,138 @@ public final class JDTUtils {
 	 * May return null if it can not associate the uri with a Java
 	 * file.
 	 *
-	 * @param uri
+	 * @param uriString
 	 * @return compilation unit
 	 */
-	public static ICompilationUnit resolveCompilationUnit(String uri) {
-		String path = null;
-		try {
-			path = new URI(uri).getPath();
-		} catch (URISyntaxException e) {
-			JavaLanguageServerPlugin.logException("Failed to resolve "+uri, e);
+	public static ICompilationUnit resolveCompilationUnit(String uriString) {
+		if (uriString == null) {
+			return null;
 		}
-		if (path != null) {
-			IFile resource = ResourcesPlugin.getWorkspace().getRoot().getFileForLocation(Path.fromOSString(path));
-			//Check if this is a Java project. In some cases project import fails
-			// to recognize project type and creates a general project
-			if(resource == null || !ProjectUtils.isJavaProject(resource.getProject())){
+		URI uri = null;
+		try {
+			uri = new URI(uriString);
+			if ("jdt".equals(uri.getScheme()) || !uri.isAbsolute()){
 				return null;
 			}
-			IJavaElement element = JavaCore.create(resource);
-			if (element instanceof ICompilationUnit) {
-				return (ICompilationUnit)element;
+		} catch (URISyntaxException e) {
+			JavaLanguageServerPlugin.logException("Failed to resolve "+uriString, e);
+		}
+
+		IFile resource= null;
+		if (uri != null) {
+			IFile[] resources = ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(uri);
+			if (resources.length > 0) {
+				resource = resources[0];
+				if(resource == null || !ProjectUtils.isJavaProject(resource.getProject())){
+					return null;
+				}
+				IJavaElement element = JavaCore.create(resource);
+				if (element instanceof ICompilationUnit) {
+					return (ICompilationUnit)element;
+				}
 			}
 		}
+		if (resource == null) {
+			return getFakeCompilationUnit(uriString);
+		}
+		//the resource is not null but no compilation unit could be created (eg. project not ready yet)
 		return null;
 	}
+
+	static ICompilationUnit getFakeCompilationUnit(String uriString) {
+		IProject project = JavaLanguageServerPlugin.getProjectsManager().getDefaultProject();
+		if (project == null || !project.isAccessible()) {
+			return null;
+		}
+		final URI uri;
+		try {
+			uri = new URI(uriString);
+		} catch (URISyntaxException e) {
+			JavaLanguageServerPlugin.logException("Failed to resolve "+uriString, e);
+			return null;
+		}
+		IJavaProject javaProject = JavaCore.create(project);
+		//Only support existing standalone java files
+		ICompilationUnit unit = null;
+
+		if ("file".equals(uri.getScheme())) {
+			java.nio.file.Path path = Paths.get(uri);
+			if (!java.nio.file.Files.isReadable(path)) {
+				return null;
+			}
+			String packageName = getPackageName(javaProject, uri);
+			String fileName = path.getName(path.getNameCount()-1).toString();
+			String packagePath = packageName.replace(".", "/");
+			final IFile file = project.getFile(new Path("src").append(packagePath).append(fileName));
+			if (!file.isLinked()) {
+				String errMsg = "Failed to create linked resource from "+uri+" to "+project.getName();
+				WorkspaceJob job = new WorkspaceJob("Create link") {
+					@Override
+					public IStatus runInWorkspace(IProgressMonitor monitor) throws CoreException {
+						try{
+							if (file.isLinked()) {
+								return Status.OK_STATUS;
+							}
+							createFolders(file.getParent(), monitor);
+							file.createLink(uri, IResource.REPLACE, monitor);
+						} catch (CoreException e) {
+							JavaLanguageServerPlugin.logException(errMsg, e);
+							return StatusFactory.newErrorStatus(errMsg);
+						}
+						return Status.OK_STATUS;
+					}
+				};
+				job.setRule(project);
+				job.schedule();
+				try {
+					job.join(1_000, new NullProgressMonitor());
+				} catch (OperationCanceledException | InterruptedException e) {
+					JavaLanguageServerPlugin.logException(errMsg, e);
+				}
+			}
+			unit = (ICompilationUnit)JavaCore.create(file, javaProject);
+		}
+		return unit;
+	}
+
+	public static void createFolders(IContainer folder, IProgressMonitor monitor) throws CoreException {
+		if (!folder.exists() && folder instanceof IFolder) {
+			IContainer parent = folder.getParent();
+			createFolders(parent, monitor);
+			folder.refreshLocal(IResource.DEPTH_ZERO, monitor);
+			if (!folder.exists()) {
+				((IFolder)folder).create(true, true, monitor);
+			}
+		}
+	}
+
+	public static String getPackageName(IJavaProject javaProject, URI uri) {
+		try {
+			File file = new File(uri);
+			//FIXME need to determine actual charset from file
+			String content = Files.toString(file, Charsets.UTF_8);
+			return getPackageName(javaProject, content);
+		} catch (Exception e) {
+			JavaLanguageServerPlugin.logException("Failed to read package name from "+uri, e);
+		}
+		return "";
+	}
+
+	public static String getPackageName(IJavaProject javaProject, String fileContent) {
+		if (fileContent == null) {
+			return "";
+		}
+		//TODO probably not the most efficient way to get the package name as this reads the whole file;
+		char[] source = fileContent.toCharArray();
+		ASTParser parser= ASTParser.newParser(AST.JLS8);
+		parser.setProject(javaProject);
+		parser.setIgnoreMethodBodies(true);
+		parser.setSource(source);
+		CompilationUnit ast = (CompilationUnit) parser.createAST(null);
+		PackageDeclaration pkg = ast.getPackage();
+		return (pkg == null || pkg.getName() == null)?"":pkg.getName().getFullyQualifiedName();
+	}
+
 
 	/**
 	 * Given the uri returns a {@link IClassFile}.
@@ -81,9 +209,24 @@ public final class JDTUtils {
 		URI uri = null;
 		try {
 			uri = new URI(uriString);
+			return resolveClassFile(uri);
 		} catch (URISyntaxException e) {
 			JavaLanguageServerPlugin.logException("Failed to resolve "+uriString, e);
 		}
+		return null;
+
+	}
+
+	/**
+	 * Given the uri returns a {@link IClassFile}.
+	 * May return null if it can not resolve the uri to a
+	 * library.
+	 *
+	 * @see #toLocation(IClassFile, int, int)
+	 * @param uri with 'jdt' scheme
+	 * @return class file
+	 */
+	public static IClassFile resolveClassFile(URI uri){
 		if (uri != null && "jdt".equals(uri.getScheme()) && "contents".equals(uri.getAuthority())) {
 			String handleId = uri.getQuery();
 			IJavaElement element = JavaCore.create(handleId);
@@ -92,7 +235,6 @@ public final class JDTUtils {
 		}
 		return null;
 	}
-
 	/**
 	 * Convenience method that combines {@link #resolveClassFile(String)} and
 	 * {@link #resolveCompilationUnit(String)}.
@@ -104,7 +246,7 @@ public final class JDTUtils {
 		try {
 			URI uri = new URI(uriString);
 			if ("jdt".equals(uri.getScheme())) {
-				return resolveClassFile(uriString);
+				return resolveClassFile(uri);
 			}
 			return resolveCompilationUnit(uriString);
 		} catch (URISyntaxException e) {

--- a/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/JavaClientConnection.java
+++ b/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/JavaClientConnection.java
@@ -69,8 +69,8 @@ public class JavaClientConnection extends LSPServer{
 		}
 	}
 
-	public JavaClientConnection() {
-		projectsManager = new ProjectsManager();
+	public JavaClientConnection(ProjectsManager projectsManager) {
+		this.projectsManager = projectsManager;
 		logHandler = new LogHandler();
 		logHandler.install(this);
 	}

--- a/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/JavaLanguageServerPlugin.java
+++ b/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/JavaLanguageServerPlugin.java
@@ -20,6 +20,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.core.IBuffer;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.WorkingCopyOwner;
+import org.jboss.tools.vscode.java.internal.managers.ProjectsManager;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
@@ -36,6 +37,7 @@ public class JavaLanguageServerPlugin implements BundleActivator {
 
 	private LanguageServer languageServer;
 	private JavaClientConnection connection;
+	private ProjectsManager projectsManager;
 
 	public static LanguageServer getLanguageServer() {
 		return pluginInstance == null? null: pluginInstance.languageServer;
@@ -48,10 +50,11 @@ public class JavaLanguageServerPlugin implements BundleActivator {
 	public void start(BundleContext bundleContext) {
 		JavaLanguageServerPlugin.context = bundleContext;
 		JavaLanguageServerPlugin.pluginInstance = this;
+		projectsManager = new ProjectsManager();
 	}
 
 	private void startConnection() throws IOException {
-		connection = new JavaClientConnection();
+		connection = new JavaClientConnection(projectsManager);
 		connection.connect();
 
 		WorkingCopyOwner.setPrimaryBufferProvider(new WorkingCopyOwner() {
@@ -77,6 +80,7 @@ public class JavaLanguageServerPlugin implements BundleActivator {
 		if (connection != null) {
 			connection.disconnect();
 		}
+		projectsManager = null;
 		connection = null;
 		languageServer = null;
 
@@ -107,5 +111,11 @@ public class JavaLanguageServerPlugin implements BundleActivator {
 			pluginInstance.languageServer = newLanguageServer;
 			pluginInstance.startConnection();
 		}
+	}
+	/**
+	 * @return
+	 */
+	public static ProjectsManager getProjectsManager() {
+		return pluginInstance.projectsManager;
 	}
 }

--- a/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/handlers/HoverHandler.java
+++ b/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/handlers/HoverHandler.java
@@ -41,6 +41,8 @@ public class HoverHandler implements RequestHandler<TextDocumentPositionParams, 
 		Hover $ = new Hover();
 		if (hover != null && hover.length() > 0) {
 			return $.withContents(hover);
+		} else {
+			$.withContents("");
 		}
 		return $.withContents("");
 	}

--- a/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/handlers/WorkspaceDiagnosticsHandler.java
+++ b/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/handlers/WorkspaceDiagnosticsHandler.java
@@ -64,9 +64,13 @@ final class WorkspaceDiagnosticsHandler implements IResourceChangeListener, IRes
 	public boolean visit(IResourceDelta delta) throws CoreException {
 		IResource resource = delta.getResource();
 		// Check if resource is accessible.
-		// We do not deal with the markers for deleted files here 
-		// WorkspaceEventsHandler removes the diagnostics for deleted resources. 
-		if(resource == null || !resource.isAccessible()) return false;
+		// We do not deal with the markers for deleted files here
+		// WorkspaceEventsHandler removes the diagnostics for deleted resources.
+		if(resource == null || !resource.isAccessible()
+				//ignore problems caused by standalone files
+				|| JavaLanguageServerPlugin.getProjectsManager().getDefaultProject().equals(resource.getProject())) {
+			return false;
+		}
 		// No marker changes continue to visit
 		if((delta.getFlags() & IResourceDelta.MARKERS) == 0 ) return true;
 

--- a/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/managers/EclipseProjectImporter.java
+++ b/org.jboss.tools.vscode.java/src/org/jboss/tools/vscode/java/internal/managers/EclipseProjectImporter.java
@@ -74,7 +74,6 @@ public class EclipseProjectImporter extends AbstractProjectImporter {
 		if (files == null || files.isEmpty()) {
 			return Collections.emptyList();
 		}
-
 		int projectSize = files.size();
 		List<IProject> projects = new ArrayList<>(projectSize);
 		subMonitor.setWorkRemaining(projectSize);
@@ -87,7 +86,7 @@ public class EclipseProjectImporter extends AbstractProjectImporter {
 				projects.add(project);
 			}
 		}
-
+		subMonitor.done();
 		return projects;
 	}
 

--- a/org.jboss.tools.vscode.tests/projects/eclipse/hello/src/NoPackage.java
+++ b/org.jboss.tools.vscode.tests/projects/eclipse/hello/src/NoPackage.java
@@ -1,0 +1,6 @@
+public class NoPackage {
+
+	public static void main(String[] args) {
+		System.out.print("Hello world!");
+	}
+}

--- a/org.jboss.tools.vscode.tests/src/org/jboss/tools/vscode/java/internal/AbstractWorkspaceTest.java
+++ b/org.jboss.tools.vscode.tests/src/org/jboss/tools/vscode/java/internal/AbstractWorkspaceTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.jboss.tools.vscode.java.internal;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+/**
+ * @author fbricon
+ *
+ */
+public abstract class AbstractWorkspaceTest {
+
+	@BeforeClass
+	public static void initWorkspace() {
+		WorkspaceHelper.initWorkspace();
+	}
+
+	@AfterClass
+	public static void cleanWorkspace() {
+		WorkspaceHelper.deleteAllProjects();
+	}
+
+
+}

--- a/org.jboss.tools.vscode.tests/src/org/jboss/tools/vscode/java/internal/JDTUtilsTest.java
+++ b/org.jboss.tools.vscode.tests/src/org/jboss/tools/vscode/java/internal/JDTUtilsTest.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.jboss.tools.vscode.java.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IPackageDeclaration;
+import org.eclipse.jdt.core.IType;
+import org.jboss.tools.vscode.java.internal.managers.ProjectsManager;
+import org.junit.Test;
+
+/**
+ * @author Fred Bricon
+ *
+ */
+public class JDTUtilsTest extends AbstractWorkspaceTest {
+
+	@Test
+	public void testGetPackageNameString() throws Exception {
+		String content = "package foo.bar.internal";
+		assertEquals("foo.bar.internal", JDTUtils.getPackageName(null, content));
+
+		content = "some junk";
+		assertEquals("", JDTUtils.getPackageName(null, content));
+
+		content = "";
+		assertEquals("", JDTUtils.getPackageName(null, content));
+
+		assertEquals("", JDTUtils.getPackageName(null, (String)null));
+	}
+
+	@Test
+	public void testGetPackageNameURI() throws Exception {
+		URI src = Paths.get("projects", "eclipse", "hello", "src", "java", "Foo.java").toUri();
+		String packageName = JDTUtils.getPackageName(null, src);
+		assertEquals("java", packageName);
+	}
+
+	@Test
+	public void testResolveStandaloneCompilationUnit() throws Exception {
+		Path helloSrcRoot = Paths.get("projects", "eclipse", "hello", "src").toAbsolutePath();
+		URI uri = helloSrcRoot.resolve(Paths.get("java", "Foo.java")).toUri();
+		ICompilationUnit cu = JDTUtils.resolveCompilationUnit(uri.toString());
+		assertNotNull("Could not find compilation unit for " + uri, cu);
+		assertEquals(ProjectsManager.DEFAULT_PROJECT_NAME, cu.getResource().getProject().getName());
+		IJavaElement[] elements = cu.getChildren();
+		assertEquals(2, elements.length);
+		assertTrue(IPackageDeclaration.class.isAssignableFrom(elements[0].getClass()));
+		assertTrue(IType.class.isAssignableFrom(elements[1].getClass()));
+
+		IResource[] resources = ResourcesPlugin.getWorkspace().getRoot().findContainersForLocationURI(uri);
+		assertEquals(1, resources.length);
+
+		uri = helloSrcRoot.resolve("NoPackage.java").toUri();
+		cu = JDTUtils.resolveCompilationUnit(uri.toString());
+		assertNotNull("Could not find compilation unit for " + uri, cu);
+		assertEquals(ProjectsManager.DEFAULT_PROJECT_NAME, cu.getResource().getProject().getName());
+		elements = cu.getChildren();
+		assertEquals(1, elements.length);
+		assertTrue(IType.class.isAssignableFrom(elements[0].getClass()));
+	}
+
+	@Test
+	public void testUnresolvableCompilationUnits() {
+		assertNull(JDTUtils.resolveCompilationUnit(null));
+		assertNull(JDTUtils.resolveCompilationUnit("foo/bar/Clazz.java"));
+		assertNull(JDTUtils.resolveCompilationUnit("file:///foo/bar/Clazz.java"));
+	}
+
+}

--- a/org.jboss.tools.vscode.tests/src/org/jboss/tools/vscode/java/internal/JobHelpers.java
+++ b/org.jboss.tools.vscode.tests/src/org/jboss/tools/vscode/java/internal/JobHelpers.java
@@ -1,0 +1,182 @@
+/*******************************************************************************
+ * Copyright (c) 2008-2010 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *      Sonatype, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.jboss.tools.vscode.java.internal;
+
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.jobs.IJobManager;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.m2e.core.internal.embedder.MavenExecutionContext;
+import org.eclipse.m2e.core.internal.jobs.IBackgroundProcessingQueue;
+import org.junit.Assert;
+
+/**
+ * Copied from m2e's org.eclipse.m2e.tests.common/src/org/eclipse/m2e/tests/common/JobHelpers.java
+ *
+ */
+@SuppressWarnings("restriction")
+public class JobHelpers {
+
+	private static final int POLLING_DELAY = 10;
+
+	public static void waitForJobsToComplete() {
+		try {
+			waitForJobsToComplete(new NullProgressMonitor());
+		} catch(Exception ex) {
+			throw new IllegalStateException(ex);
+		}
+	}
+
+	public static void waitForJobsToComplete(IProgressMonitor monitor) throws InterruptedException, CoreException {
+		waitForBuildJobs();
+
+		/*
+		 * First, make sure refresh job gets all resource change events
+		 *
+		 * Resource change events are delivered after WorkspaceJob#runInWorkspace returns
+		 * and during IWorkspace#run. Each change notification is delivered by
+		 * only one thread/job, so we make sure no other workspaceJob is running then
+		 * call IWorkspace#run from this thread.
+		 *
+		 * Unfortunately, this does not catch other jobs and threads that call IWorkspace#run
+		 * so we have to hard-code workarounds
+		 *
+		 * See http://www.eclipse.org/articles/Article-Resource-deltas/resource-deltas.html
+		 */
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		IJobManager jobManager = Job.getJobManager();
+		jobManager.suspend();
+		try {
+			Job[] jobs = jobManager.find(null);
+			for(int i = 0; i < jobs.length; i++ ) {
+				if(jobs[i] instanceof WorkspaceJob || jobs[i].getClass().getName().endsWith("JREUpdateJob")) {
+					jobs[i].join();
+				}
+			}
+			workspace.run(new IWorkspaceRunnable() {
+				@Override
+				public void run(IProgressMonitor monitor) {
+				}
+			}, workspace.getRoot(), 0, monitor);
+
+			// Now we flush all background processing queues
+			boolean processed = flushProcessingQueues(jobManager, monitor);
+			for(int i = 0; i < 10 && processed; i++ ) {
+				processed = flushProcessingQueues(jobManager, monitor);
+				try {
+					Thread.sleep(10);
+				} catch(InterruptedException e) {
+				}
+			}
+
+			Assert.assertFalse("Could not flush background processing queues: " + getProcessingQueues(jobManager), processed);
+		} finally {
+			jobManager.resume();
+		}
+
+		waitForBuildJobs();
+	}
+
+	private static boolean flushProcessingQueues(IJobManager jobManager, IProgressMonitor monitor)
+			throws InterruptedException, CoreException {
+		boolean processed = false;
+		for(IBackgroundProcessingQueue queue : getProcessingQueues(jobManager)) {
+			queue.join();
+			if(!queue.isEmpty()) {
+				Deque<MavenExecutionContext> context = MavenExecutionContext.suspend();
+				try {
+					IStatus status = queue.run(monitor);
+					if(!status.isOK()) {
+						throw new CoreException(status);
+					}
+					processed = true;
+				} finally {
+					MavenExecutionContext.resume(context);
+				}
+			}
+			if(queue.isEmpty()) {
+				queue.cancel();
+			}
+		}
+		return processed;
+	}
+
+	private static List<IBackgroundProcessingQueue> getProcessingQueues(IJobManager jobManager) {
+		ArrayList<IBackgroundProcessingQueue> queues = new ArrayList<>();
+		for(Job job : jobManager.find(null)) {
+			if(job instanceof IBackgroundProcessingQueue) {
+				queues.add((IBackgroundProcessingQueue) job);
+			}
+		}
+		return queues;
+	}
+
+	private static void waitForBuildJobs() {
+		waitForJobs(BuildJobMatcher.INSTANCE, 60 * 1000);
+	}
+
+	public static void waitForJobs(IJobMatcher matcher, int maxWaitMillis) {
+		final long limit = System.currentTimeMillis() + maxWaitMillis;
+		while(true) {
+			Job job = getJob(matcher);
+			if(job == null) {
+				return;
+			}
+			boolean timeout = System.currentTimeMillis() > limit;
+			Assert.assertFalse("Timeout while waiting for completion of job: " + job, timeout);
+			job.wakeUp();
+			try {
+				Thread.sleep(POLLING_DELAY);
+			} catch(InterruptedException e) {
+				// ignore and keep waiting
+			}
+		}
+	}
+
+	private static Job getJob(IJobMatcher matcher) {
+		Job[] jobs = Job.getJobManager().find(null);
+		for(Job job : jobs) {
+			if(matcher.matches(job)) {
+				return job;
+			}
+		}
+		return null;
+	}
+
+	public static interface IJobMatcher {
+
+		boolean matches(Job job);
+
+	}
+
+	static class BuildJobMatcher implements IJobMatcher {
+
+		public static final IJobMatcher INSTANCE = new BuildJobMatcher();
+
+		@Override
+		public boolean matches(Job job) {
+			return (job instanceof WorkspaceJob) || job.getClass().getName().matches("(.*\\.AutoBuild.*)")
+					|| job.getClass().getName().endsWith("JREUpdateJob");
+		}
+
+	}
+
+}

--- a/org.jboss.tools.vscode.tests/src/org/jboss/tools/vscode/java/internal/WorkspaceHelper.java
+++ b/org.jboss.tools.vscode.tests/src/org/jboss/tools/vscode/java/internal/WorkspaceHelper.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.jboss.tools.vscode.java.internal;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+/**
+ * @author Fred Bricon
+ *
+ */
+public class WorkspaceHelper {
+
+	private WorkspaceHelper() {
+		//No instances allowed
+	}
+
+	public static void initWorkspace() {
+		List<IProject> projects = new ArrayList<>(1);
+		JavaLanguageServerPlugin.getProjectsManager().createProject(null, projects, new NullProgressMonitor());
+		assertEquals(1, projects.size());
+	}
+
+	public static void deleteAllProjects() {
+		IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
+		Stream.of(projects).forEach(p -> delete(p));
+	}
+
+	public static void delete(IProject project) {
+		try {
+			project.delete(true, new NullProgressMonitor());
+		} catch (CoreException e) {
+			e.printStackTrace();
+		}
+	}
+
+}

--- a/org.jboss.tools.vscode.tests/src/org/jboss/tools/vscode/java/internal/managers/AbstractProjectsManagerBasedTest.java
+++ b/org.jboss.tools.vscode.tests/src/org/jboss/tools/vscode/java/internal/managers/AbstractProjectsManagerBasedTest.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.jboss.tools.vscode.java.internal.managers;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -18,15 +17,13 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.jboss.tools.vscode.java.internal.ProjectUtils;
+import org.jboss.tools.vscode.java.internal.WorkspaceHelper;
 import org.junit.After;
 import org.junit.Before;
 
@@ -42,13 +39,6 @@ public abstract class AbstractProjectsManagerBasedTest {
 	@Before
 	public void initProjectManager() {
 		projectsManager = new ProjectsManager();
-	}
-
-
-	protected IProject importProject(String path) throws IOException {
-		List<IProject> resultingProjects = importProjects(path);
-		assertEquals("Expected to import 1 project", 1, resultingProjects.size());
-		return resultingProjects.get(0);
 	}
 
 	protected List<IProject> importProjects(String path) throws IOException {
@@ -78,21 +68,8 @@ public abstract class AbstractProjectsManagerBasedTest {
 	@After
 	public void cleanUp() throws Exception {
 		projectsManager = null;
-		deleteAllProjects();
+		WorkspaceHelper.deleteAllProjects();
 		FileUtils.forceDelete(getWorkingProjectDirectory());
-	}
-
-	protected void deleteAllProjects() {
-		IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
-		Stream.of(projects).forEach(p -> delete(p));
-	}
-
-	protected void delete(IProject project) {
-		try {
-			project.delete(true, monitor);
-		} catch (CoreException e) {
-			e.printStackTrace();
-		}
 	}
 
 	protected void assertIsJavaProject(IProject project) {

--- a/org.jboss.tools.vscode.tests/src/org/jboss/tools/vscode/java/internal/managers/EclipseProjectImporterTest.java
+++ b/org.jboss.tools.vscode.tests/src/org/jboss/tools/vscode/java/internal/managers/EclipseProjectImporterTest.java
@@ -36,20 +36,20 @@ public class EclipseProjectImporterTest extends AbstractProjectsManagerBasedTest
 
 	@Test
 	public void importSimpleJavaProject() throws Exception {
-		IProject project = importProject("eclipse/hello");
+		IProject project = importProjects("eclipse/hello").get(1);
 		assertIsJavaProject(project);
 	}
 
 	@Test
 	public void importMultipleJavaProject() throws Exception {
 		List<IProject> projects = importProjects("eclipse/multi");
-		assertEquals(2, projects.size());
+		assertEquals(3, projects.size());
 
-		IProject bar = projects.get(0);
+		IProject bar = projects.get(1);
 		assertIsJavaProject(bar);
 		assertEquals("bar", bar.getName());
 
-		IProject foo = projects.get(1);
+		IProject foo = projects.get(2);
 		assertEquals("foo", foo.getName());
 		assertIsJavaProject(foo);
 	}

--- a/org.jboss.tools.vscode.tests/src/org/jboss/tools/vscode/java/internal/managers/ProjectsManagerTest.java
+++ b/org.jboss.tools.vscode.tests/src/org/jboss/tools/vscode/java/internal/managers/ProjectsManagerTest.java
@@ -10,31 +10,33 @@
  *******************************************************************************/
 package org.jboss.tools.vscode.java.internal.managers;
 
-import static org.jboss.tools.vscode.java.internal.ProjectUtils.getJavaSourceLevel;
+import static org.jboss.tools.vscode.java.internal.JobHelpers.waitForJobsToComplete;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.core.resources.IProject;
-import org.jboss.tools.vscode.java.internal.ProjectUtils;
 import org.junit.Test;
 
 /**
  * @author Fred Bricon
+ *
  */
-public class MavenProjectImporterTest extends AbstractProjectsManagerBasedTest {
+public class ProjectsManagerTest extends AbstractProjectsManagerBasedTest {
 
 	@Test
-	public void importSimpleJavaProject() throws Exception {
-		IProject project = importProjects("maven/salut").get(1);
-		assertIsJavaProject(project);
-		assertIsMavenProject(project);
-		assertEquals("1.7", getJavaSourceLevel(project));
-	}
-
-	protected void assertIsMavenProject(IProject project) {
-		assertNotNull(project);
-		assertTrue(project.getName() +" is missing the Maven nature", ProjectUtils.isMavenProject(project));
+	public void testCreateDefaultProject() throws Exception {
+		List<IProject> projects = new ArrayList<>();
+		projectsManager.createProject(null, projects, monitor);
+		waitForJobsToComplete();
+		assertEquals(1, projects.size());
+		IProject result = projects.get(0);
+		assertNotNull(result);
+		assertEquals(projectsManager.getDefaultProject(), result);
+		assertTrue("the default project doesn't exist", result.exists());
 	}
 
 }


### PR DESCRIPTION
Standalone Java files are linked to a default Java project providing a default classpath allowing for content assist for Base JDK classes

For now the main problem is we lose Java support when a Java file opened in memory (i.e not backed by an existing file on disk) is saved. 

Signed-off-by: Fred Bricon fbricon@gmail.com
