### PR TITLE
Consume commons lang3, lsp4j and gson from update sites.

### DIFF
--- a/org.jboss.tools.vscode.java/.classpath
+++ b/org.jboss.tools.vscode.java/.classpath
@@ -2,19 +2,11 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry exported="true" kind="lib" path="lib/commons-lang3-3.4.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/jsoup-1.9.2.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/remark-1.0.0.jar"/>
-	<classpathentry kind="src" path="src/"/>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry exported="true" kind="lib" path="lib/junixsocket-common-2.0.4.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/junixsocket-native-common-2.0.4.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/log4j-1.2.17.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/native-lib-loader-2.0.2.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/gson-2.7.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/org.eclipse.lsp4j-0.1.0-SNAPSHOT.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/org.eclipse.lsp4j.annotations-0.1.0-SNAPSHOT.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/org.eclipse.lsp4j.jsonrpc-0.1.0-SNAPSHOT.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/org.eclipse.xtend.lib-2.10.0.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/org.eclipse.xtext.xbase.lib-2.10.0.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/org.jboss.tools.vscode.java/META-INF/MANIFEST.MF
+++ b/org.jboss.tools.vscode.java/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-Activator: org.jboss.tools.vscode.java.internal.JavaLanguageServerPlugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.osgi.framework;version="1.3.0"
 Bundle-ActivationPolicy: lazy
+Bundle-Localization: plugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.core.resources,
  org.eclipse.jdt.core,
@@ -22,7 +23,12 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  com.gradleware.tooling.utils;bundle-version="0.14.0",
  org.gradle.toolingapi,
  org.eclipse.jdt.launching,
- org.eclipse.jdt.core.manipulation;bundle-version="1.8.0"
+ org.eclipse.jdt.core.manipulation;bundle-version="1.8.0",
+ com.google.gson,
+ org.eclipse.lsp4j;bundle-version="0.1.0",
+ org.eclipse.lsp4j.jsonrpc;bundle-version="0.1.0",
+ org.apache.commons.lang3;bundle-version="3.1.0",
+ org.apache.log4j;bundle-version="1.2.15"
 Export-Package: org.eclipse.lsp4j;x-friends:="org.jboss.tools.vscode.tests",
  org.eclipse.lsp4j.jsonrpc;x-friends:="org.jboss.tools.vscode.tests",
  org.eclipse.lsp4j.jsonrpc.json;x-friends:="org.jboss.tools.vscode.tests",
@@ -35,17 +41,10 @@ Export-Package: org.eclipse.lsp4j;x-friends:="org.jboss.tools.vscode.tests",
  org.jboss.tools.vscode.java.internal.javadoc;x-friends:="org.jboss.tools.vscode.tests",
  org.jboss.tools.vscode.java.internal.managers;x-friends:="org.jboss.tools.vscode.tests",
  org.jboss.tools.vscode.java.internal.preferences;x-friends:="org.jboss.tools.vscode.tests"
-Bundle-ClassPath: lib/commons-lang3-3.4.jar,
- lib/jsoup-1.9.2.jar,
+Bundle-ClassPath: lib/jsoup-1.9.2.jar,
  lib/remark-1.0.0.jar,
  .,
  lib/junixsocket-common-2.0.4.jar,
  lib/junixsocket-native-common-2.0.4.jar,
  lib/log4j-1.2.17.jar,
- lib/native-lib-loader-2.0.2.jar,
- lib/gson-2.7.jar,
- lib/org.eclipse.lsp4j-0.1.0-SNAPSHOT.jar,
- lib/org.eclipse.lsp4j.annotations-0.1.0-SNAPSHOT.jar,
- lib/org.eclipse.lsp4j.jsonrpc-0.1.0-SNAPSHOT.jar,
- lib/org.eclipse.xtend.lib-2.10.0.jar,
- lib/org.eclipse.xtext.xbase.lib-2.10.0.jar
+ lib/native-lib-loader-2.0.2.jar

--- a/org.jboss.tools.vscode.java/build.properties
+++ b/org.jboss.tools.vscode.java/build.properties
@@ -3,16 +3,9 @@ output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               lib/commons-lang3-3.4.jar,\
                lib/jsoup-1.9.2.jar,\
                lib/remark-1.0.0.jar,\
                lib/junixsocket-common-2.0.4.jar,\
                lib/junixsocket-native-common-2.0.4.jar,\
-               lib/log4j-1.2.17.jar,\
                lib/native-lib-loader-2.0.2.jar,\
-               lib/gson-2.7.jar,\
-               lib/org.eclipse.lsp4j-0.1.0-SNAPSHOT.jar,\
-               lib/org.eclipse.lsp4j.annotations-0.1.0-SNAPSHOT.jar,\
-               lib/org.eclipse.lsp4j.jsonrpc-0.1.0-SNAPSHOT.jar,\
-               lib/org.eclipse.xtend.lib-2.10.0.jar,\
-               lib/org.eclipse.xtext.xbase.lib-2.10.0.jar
+               plugin.properties

--- a/org.jboss.tools.vscode.java/plugin.properties
+++ b/org.jboss.tools.vscode.java/plugin.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2017 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial implementation
+###############################################################################
+bundleVendor=Eclipse.org
+bundleName=Java LSP Server

--- a/org.jboss.tools.vscode.java/pom.xml
+++ b/org.jboss.tools.vscode.java/pom.xml
@@ -24,29 +24,9 @@
 							<version>1.0.0</version>
 						</artifactItem>
 						<artifactItem>
-							<groupId>org.apache.commons</groupId>
-							<artifactId>commons-lang3</artifactId>
-							<version>3.4</version>
-						</artifactItem>
-						<artifactItem>
 							<groupId>org.jsoup</groupId>
 							<artifactId>jsoup</artifactId>
 							<version>1.9.2</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.eclipse.lsp4j</groupId>
-							<artifactId>org.eclipse.lsp4j</artifactId>
-							<version>0.1.0-SNAPSHOT</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.eclipse.lsp4j</groupId>
-							<artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
-							<version>0.1.0-SNAPSHOT</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.eclipse.lsp4j</groupId>
-							<artifactId>org.eclipse.lsp4j.annotations</artifactId>
-							<version>0.1.0-SNAPSHOT</version>
 						</artifactItem>
 						<artifactItem>
 							<groupId>com.kohlschutter.junixsocket</groupId>
@@ -59,29 +39,9 @@
 							<version>2.0.4</version>
 						</artifactItem>
 						<artifactItem>
-							<groupId>log4j</groupId>
-							<artifactId>log4j</artifactId>
-							<version>1.2.17</version>
-						</artifactItem>
-						<artifactItem>
 							<groupId>org.scijava</groupId>
 							<artifactId>native-lib-loader</artifactId>
 							<version>2.0.2</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>com.google.code.gson</groupId>
-							<artifactId>gson</artifactId>
-							<version>2.7</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.eclipse.xtend</groupId>
-							<artifactId>org.eclipse.xtend.lib</artifactId>
-							<version>2.10.0</version>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.eclipse.xtext</groupId>
-							<artifactId>org.eclipse.xtext.xbase.lib</artifactId>
-							<version>2.10.0</version>
 						</artifactItem>
 					</artifactItems>
 				</configuration>
@@ -114,6 +74,11 @@
 			<groupId>org.eclipse.lsp4j</groupId>
 			<artifactId>org.eclipse.lsp4j</artifactId>
 			<version>0.1.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<version>1.2.14</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/org.jboss.tools.vscode.product/pom.xml
+++ b/org.jboss.tools.vscode.product/pom.xml
@@ -72,6 +72,7 @@
 							<goal>copy-resources</goal>
 						</goals>
 						<configuration>
+							<encoding>UTF-8</encoding>
 							<outputDirectory>${project.build.directory}/repository/config_mac</outputDirectory>
 							<resources>
 								<resource>
@@ -87,6 +88,7 @@
 							<goal>copy-resources</goal>
 						</goals>
 						<configuration>
+							<encoding>UTF-8</encoding>
 							<outputDirectory>${project.build.directory}/repository/config_win</outputDirectory>
 							<resources>
 								<resource>
@@ -102,6 +104,7 @@
 							<goal>copy-resources</goal>
 						</goals>
 						<configuration>
+							<encoding>UTF-8</encoding>
 							<outputDirectory>${project.build.directory}/repository/config_linux</outputDirectory>
 							<resources>
 								<resource>
@@ -157,6 +160,7 @@
 									<goal>copy-resources</goal>
 								</goals>
 								<configuration>
+									<encoding>UTF-8</encoding>
 									<outputDirectory>${vscode.location}/server</outputDirectory>
 									<resources>
 										<resource>

--- a/org.jboss.tools.vscode.tests/META-INF/MANIFEST.MF
+++ b/org.jboss.tools.vscode.tests/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Tests
+Bundle-Name: %bundleName
 Bundle-SymbolicName: org.jboss.tools.vscode.tests;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: org.osgi.framework;version="1.3.0"
 Bundle-ActivationPolicy: lazy
+Bundle-Localization: plugin
 Require-Bundle: org.jboss.tools.vscode.java,
  org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.core.resources,
@@ -20,4 +21,6 @@ Require-Bundle: org.jboss.tools.vscode.java,
  org.junit;bundle-version="4.12.0",
  org.mockito.mockito-all;bundle-version="1.9.5",
  org.apache.commons.io;bundle-version="2.2.0",
- org.eclipse.buildship.core;bundle-version="1.0.18"
+ org.eclipse.buildship.core;bundle-version="1.0.18",
+ com.google.gson;bundle-version="2.2.4"
+Bundle-Vendor: %bundleVendor

--- a/org.jboss.tools.vscode.tests/build.properties
+++ b/org.jboss.tools.vscode.tests/build.properties
@@ -2,4 +2,5 @@ source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               plugin.properties

--- a/org.jboss.tools.vscode.tests/plugin.properties
+++ b/org.jboss.tools.vscode.tests/plugin.properties
@@ -1,0 +1,12 @@
+###############################################################################
+# Copyright (c) 2017 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     IBM Corporation - initial implementation
+###############################################################################
+bundleVendor=Eclipse.org
+bundleName=Java LSP Server Tests

--- a/target-platform/jdt_ls.target
+++ b/target-platform/jdt_ls.target
@@ -1,13 +1,15 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="Java Language Server Target Definition" sequenceNumber="51">
+<?xml version="1.0" encoding="UTF-8"?><?pde version="3.8"?><target name="Java Language Server Target Definition" sequenceNumber="55">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.mockito.mockito-all" version="1.9.5"/>
 <repository location="http://download.eclipse.org/scout/releases/4.0/testing"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="com.google.gson" version="2.2.4.v201311231704"/>
+<unit id="com.google.gson.source" version="2.2.4.v201311231704"/>
 <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
 <unit id="org.apache.commons.lang3" version="3.1.0.v201403281430"/>
+<unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
 <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/S20160916162009/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
@@ -16,8 +18,6 @@
 <repository location="http://download.eclipse.org/releases/oxygen"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.jdt.source.feature.group" version="3.13.0.v20170104-2000"/>
-<unit id="org.eclipse.sdk.feature.group" version="4.7.0.v20170104-2000"/>
 <unit id="org.eclipse.equinox.core.feature.feature.group" version="1.4.0.v20170103-2026"/>
 <unit id="org.eclipse.equinox.core.sdk.feature.group" version="3.13.0.v20170103-2026"/>
 <unit id="org.eclipse.equinox.executable.feature.group" version="3.7.0.v20161219-1356"/>
@@ -25,7 +25,15 @@
 <unit id="org.eclipse.equinox.p2.core.feature.source.feature.group" version="1.4.0.v20161031-1443"/>
 <unit id="org.eclipse.equinox.p2.rcp.feature.feature.group" version="1.3.0.v20161123-1821"/>
 <unit id="org.eclipse.equinox.sdk.feature.group" version="3.13.0.v20170103-2026"/>
+<unit id="org.eclipse.jdt.source.feature.group" version="3.13.0.v20170104-2000"/>
+<unit id="org.eclipse.sdk.feature.group" version="4.7.0.v20170104-2000"/>
 <repository location="http://download.eclipse.org/eclipse/updates/4.7-I-builds"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="com.google.gson" version="2.7.0.v20161205-1708"/>
+<unit id="com.google.gson.source" version="2.7.0.v20161205-1708"/>
+<unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.1.0.v20170105-0805"/>
+<repository location="http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastSuccessfulBuild/artifact/build/p2-repository/"/>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>


### PR DESCRIPTION
Consume commons lang3, lsp4j and gson from update sites.

This removes lots of inner jars from the org.jboss.tools.vscode.java
bundle and makes us consuming the latest lsp4j bundles.

I got a successful local maven build with these changes.

Change-Id: Ie721036794f5a9c85a00e76dcc0c18d31d0e2c40
Signed-off-by: oliviert <Olivier_Thomann@ca.ibm.com>